### PR TITLE
Fixing Broken links

### DIFF
--- a/content/en/enterprise/index.mdx
+++ b/content/en/enterprise/index.mdx
@@ -59,7 +59,3 @@ We are also here to help! We can offer various forms of [support](/enterprise/su
 <LeadCapture />
 
 ![Learn](/images/creatures/octopus/octopus-full-light.svg)
-
-<Aligner center>
-  <Button to="/setup/module-0/">Begin!</Button>
-</Aligner>

--- a/content/en/setup/index.mdx
+++ b/content/en/setup/index.mdx
@@ -21,11 +21,11 @@ The Marketplace Launchpad is a step-by-step guide on how to setup and launch you
 
 ### Content
 
-| Orientation                                                     | Marketplace Quickstart Guide                            |
-| --------------------------------------------------------------- | ------------------------------------------------------- |
-| [Our Mission Statement](/setup/orientation/mission-statement)   | [Technical Deep Dive](/setup/quickstart/module-1/)      |
-| [Introduction to Web3](/setup/orientation/intro-to-web3)        | [Forking Ocean Market](/setup/quickstart/module-2/)     |
-| [Settting up a Wallet](/setup/orientation/wallet-basics)        | [Setup Backend Components](/setup/quickstart/module-3/) |
-| [Using Ocean Marketplace](/setup/orientation/marketplace-intro) | [Deployment](/setup/quickstart/module-4/)               |
+| Orientation                                                     | Marketplace Quickstart Guide                           |
+| --------------------------------------------------------------- | ------------------------------------------------------ |
+| [Our Mission Statement](/setup/orientation/mission-statement)   | [Technical Deep Dive](/setup/module-1)                 |
+| [Introduction to Web3](/setup/orientation/intro-to-web3)        | [Forking Ocean Market](/setup/module-2/)               |
+| [Settting up a Wallet](/setup/orientation/wallet-basics)        | [Deploy your market](/setup/module-2/deploying-market) |
+| [Using Ocean Marketplace](/setup/orientation/marketplace-intro) | [Backend Overview](/setup/module-3)                    |
 
 ![Learn](/images/creatures/octopus/octopus-full-light.svg)


### PR DESCRIPTION
Fixes: #37 
Fixes: #36 

 - Fixing broken links on the setup guide page
 - Removing begin button on the enterprise page